### PR TITLE
Add OpenAPI plugin

### DIFF
--- a/docs/_api/plugins.md
+++ b/docs/_api/plugins.md
@@ -36,6 +36,7 @@ permalink: /docs/plugins-api/
     -   [conditionalRequest][27]
     -   [auditLogger][28]
     -   [metrics][29]
+    -   [openapi][60]
 -   [Types][30]
     -   [metrics~callback][31]
 -   [req.set][32]
@@ -1206,6 +1207,33 @@ server.on('after', restify.plugins.metrics({ server: server },
 Returns **[Function][35]** returns a function suitable to be used
   with restify server's `after` event
 
+### openapi
+
+Generates an OpenAPI specification from the server's routes and serves it at a
+configurable endpoint.
+
+**Parameters**
+
+-   `opts` **[Object][39]** options
+    -   `opts.server` **Server** restify server instance
+    -   `opts.path` **[String][41]?** path where the spec is exposed
+    -   `opts.version` **[String][41]?** API version reported in the spec
+    -   `opts.info` **[Object][39]?** additional info object
+    -   `opts.servers` **[Array][40]?** list of server objects for the spec
+    -   `opts.schemas` **[Object][39]?** schema definitions
+
+**Examples**
+
+```javascript
+server.use(restify.plugins.openapi({
+  server: server,
+  path: '/openapi.json',
+  version: '1.0.0'
+}));
+```
+
+Returns **[Function][35]** Handler
+
 ## Types
 
 
@@ -1391,3 +1419,4 @@ Returns **any** value stored in context
 [58]: https://developer.mozilla.org/docs/Web/Guide/HTML/HTML5
 
 [59]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined
+[60]: #openapi

--- a/docs/config/plugins.yaml
+++ b/docs/config/plugins.yaml
@@ -34,6 +34,7 @@ toc:
       - conditionalRequest
       - auditLogger
       - metrics
+      - openapi
   - name: Types
     children:
       - metrics~callback

--- a/docs/guides/openapi.md
+++ b/docs/guides/openapi.md
@@ -1,0 +1,32 @@
+# OpenAPI Plugin
+
+Restify's OpenAPI plugin generates a simple OpenAPI 3 specification from the
+routes registered on a server and exposes it via an HTTP endpoint.
+
+## Usage
+
+```js
+const restify = require('restify');
+const server = restify.createServer();
+
+// register your routes
+server.get('/foo', function (req, res, next) {
+  res.send('foo');
+  next();
+});
+
+// expose the spec under /openapi.json
+server.use(
+  restify.plugins.openapi({
+    server: server,
+    path: '/openapi.json',
+    version: '1.0.0',
+    info: { title: 'Example Service' }
+  })
+);
+
+server.listen(8080);
+```
+
+Requesting `/openapi.json` will return a JSON representation of the generated
+specification containing all registered routes.

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -23,6 +23,7 @@ module.exports = {
     oauth2TokenParser: require('./oauth2TokenParser'),
     queryParser: require('./query'),
     metrics: require('./metrics'),
+    openapi: require('./openapi'),
     requestExpiry: require('./requestExpiry'),
     requestLogger: require('./requestLogger'),
     serveStatic: require('./static'),

--- a/lib/plugins/openapi.js
+++ b/lib/plugins/openapi.js
@@ -1,0 +1,78 @@
+'use strict';
+
+var assert = require('assert-plus');
+
+/**
+ * Collects route metadata from a restify server and exposes an endpoint
+ * that serves an OpenAPI specification document. The spec is generated
+ * on demand from the server's registered routes.
+ *
+ * @public
+ * @function openapi
+ * @param {Object} opts - plugin options
+ * @param {Server} opts.server - restify server instance
+ * @param {String} [opts.path='/openapi.json'] - path of the spec endpoint
+ * @param {String} [opts.version='1.0.0'] - API version
+ * @param {Object} [opts.info] - additional info object for the spec
+ * @param {Object} [opts.servers] - array of server objects for the spec
+ * @param {Object} [opts.schemas] - components.schemas definitions
+ * @returns {Function} restify middleware
+ *
+ * @example
+ * // create server and expose the spec under /spec
+ * server.use(restify.plugins.openapi({
+ *     server: server,
+ *     path: '/spec',
+ *     version: '1.2.3',
+ *     info: { title: 'my api' }
+ * }));
+ */
+function openapi(opts) {
+    assert.object(opts, 'opts');
+    assert.object(opts.server, 'opts.server');
+    assert.optionalString(opts.path, 'opts.path');
+    assert.optionalString(opts.version, 'opts.version');
+    assert.optionalObject(opts.info, 'opts.info');
+    assert.optionalArray(opts.servers, 'opts.servers');
+    assert.optionalObject(opts.schemas, 'opts.schemas');
+
+    var server = opts.server;
+    var specPath = opts.path || '/openapi.json';
+    var apiVersion = opts.version || '1.0.0';
+    var info = opts.info || {};
+    var serverList = opts.servers || [{ url: server.url || '' }];
+    var schemas = opts.schemas || {};
+
+    function buildSpec() {
+        var routes = server.router.getRoutes();
+        var paths = {};
+        Object.keys(routes).forEach(function buildPath(name) {
+            var r = routes[name];
+            var method = r.method.toLowerCase();
+            if (!paths[r.path]) {
+                paths[r.path] = {};
+            }
+            paths[r.path][method] = {
+                operationId: name
+            };
+        });
+        return {
+            openapi: '3.0.0',
+            info: Object.assign({ title: server.name, version: apiVersion }, info),
+            servers: serverList,
+            paths: paths,
+            components: { schemas: schemas }
+        };
+    }
+
+    server.get(specPath, function sendSpec(req, res, next) {
+        res.send(buildSpec());
+        return next();
+    });
+
+    return function _openapi(req, res, next) {
+        return next();
+    };
+}
+
+module.exports = openapi;

--- a/test/plugins/openapi.test.js
+++ b/test/plugins/openapi.test.js
@@ -1,0 +1,59 @@
+'use strict';
+/* eslint-disable func-names */
+
+var assert = require('chai').assert;
+var restify = require('../../lib/index.js');
+var restifyClients = require('restify-clients');
+var helper = require('../lib/helper');
+
+var SERVER;
+var CLIENT;
+var PORT;
+
+describe('openapi plugin', function() {
+    beforeEach(function(done) {
+        SERVER = restify.createServer({
+            dtrace: helper.dtrace,
+            log: helper.getLog('server')
+        });
+
+        SERVER.get('/foo', function(req, res, next) {
+            res.send({ foo: true });
+            next();
+        });
+        SERVER.post('/bar', function(req, res, next) {
+            res.send(201, { bar: true });
+            next();
+        });
+
+        SERVER.use(restify.plugins.openapi({ server: SERVER }));
+
+        SERVER.listen(0, '127.0.0.1', function() {
+            PORT = SERVER.address().port;
+            CLIENT = restifyClients.createJsonClient({
+                url: 'http://127.0.0.1:' + PORT,
+                dtrace: helper.dtrace,
+                retry: false
+            });
+            done();
+        });
+    });
+
+    afterEach(function(done) {
+        CLIENT.close();
+        SERVER.close(done);
+    });
+
+    it('should include all routes in generated spec', function(done) {
+        CLIENT.get('/openapi.json', function(err, req, res, obj) {
+            assert.ifError(err);
+            assert.equal(res.statusCode, 200);
+            assert.isObject(obj.paths);
+            assert.isObject(obj.paths['/foo']);
+            assert.isObject(obj.paths['/bar']);
+            assert.isObject(obj.paths['/foo'].get);
+            assert.isObject(obj.paths['/bar'].post);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add new openapi plugin for exposing an OpenAPI specification
- document the plugin and usage
- include openapi in plugins export and docs config
- test openapi plugin spec generation

## Testing
- `npm test` *(fails: ./node_modules/.bin/eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a745f07dc832594cf3236b62e3ad5